### PR TITLE
Issue #2: Integrate ESLint's `--no-eslintrc` command line option

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^5.6 || ^7.0",
-        "phpro/grumphp": "^0.11"
+        "phpro/grumphp": "~0.11"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^1.11",

--- a/src/ESLint.php
+++ b/src/ESLint.php
@@ -54,11 +54,13 @@ final class ESLint extends AbstractExternalTask
         $resolver = new OptionsResolver();
         $resolver->setDefaults(
             [
+                'no_eslintrc' => false,
                 'config' => null,
                 'debug' => false,
             ]
         );
 
+        $resolver->addAllowedTypes('no_eslintrc', ['bool']);
         $resolver->addAllowedTypes('config', ['null', 'string']);
         $resolver->addAllowedTypes('debug', ['bool']);
 
@@ -93,6 +95,7 @@ final class ESLint extends AbstractExternalTask
 
         $arguments = $this->processBuilder->createArgumentsForCommand('eslint');
         $arguments->add('--format=table');
+        $arguments->addOptionalArgument('--no-eslintrc', $config['no_eslintrc']);
         $arguments->addOptionalArgument('--config %s', $config['config']);
         $arguments->addOptionalArgument('--debug', $config['debug']);
 


### PR DESCRIPTION
This PR extends the ESLint task with the --no-eslintrc option. It can be configured within the grumphp.yml using the no_eslintc: true option:

```parameters:
  bin_dir: "./bin"
  git_dir: "."
  tasks:
    eslint:
      config: ./.eslintrc.json
      # Ignore sub project eslinrc.
      no_eslintrc: true
services:
  task.eslint:
    class: Stickee\GrumPHP\ESLint
    arguments:
      - '@config'
      - '@process_builder'
      - '@formatter.raw_process'
    tags:
      - {name: grumphp.task, config: eslint}```